### PR TITLE
Make `Chat` fully public

### DIFF
--- a/Sources/SwiftLlama/Models/Chat.swift
+++ b/Sources/SwiftLlama/Models/Chat.swift
@@ -1,8 +1,14 @@
 import Foundation
 
 public struct Chat {
-    let user: String
-    let bot: String
+    public let user: String
+    public let bot: String
+
+    // The default initializer is unfortunately internal. So we have to define it explicitly.
+    public init(user: String, bot: String) {
+        self.user = user
+        self.bot = bot
+    }
 }
 
 extension Chat {


### PR DESCRIPTION
Make `Chat` fully public, so that the consumer project is capable of constructing a history.