### PR TITLE
Update Configuration.swift

### DIFF
--- a/Sources/SwiftLlama/Models/Configuration.swift
+++ b/Sources/SwiftLlama/Models/Configuration.swift
@@ -45,5 +45,5 @@ extension Configuration {
         return params
     }
 
-    static var historySize = 5
+    public static var historySize = 5
 }


### PR DESCRIPTION
Expose historySize to public. Ideally we shouldn't need to rely on this. Configuration.historyLimit should be used instead.