### PR TITLE
Update SwiftllamaActor.swift

### DIFF
--- a/Sources/SwiftLlama/SwiftllamaActor.swift
+++ b/Sources/SwiftLlama/SwiftllamaActor.swift
@@ -1,6 +1,6 @@
 import Foundation
 
 @globalActor
-actor SwiftLlamaActor {
-    static let shared = SwiftLlamaActor()
+public actor SwiftLlamaActor {
+    public static let shared = SwiftLlamaActor()
 }


### PR DESCRIPTION
The actor need to be public because it's used on public APIs.