### PR TITLE
Updated `Package.swift` to use stable version of `llama.cpp`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "SwiftLlama", targets: ["SwiftLlama"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ggerganov/llama.cpp.git", branch: "master")
+        .package(url: "https://github.com/ggerganov/llama.cpp.git", exact: "b3889"),
     ],
     targets: [
         .target(name: "SwiftLlama", 


### PR DESCRIPTION
When integrating SPM packages from a `Package.swift` file, which is the done thing when modularising your app via local SPM packages - you run into an error that is not found when integrating this SPM package via Xcodes UI. 

This error appears because we are using the branch `master` when referring to which version of `llama.cpp` to pull from. Swift does not recognise this as a stable release of `llama.cpp` and fails the resolution.

This change makes SPM happy when integrating from the `Package.swift` file.