### PR TITLE
Update: Add Gemma prompt format

### DIFF
--- a/Sources/SwiftLlama/Models/Chat.swift
+++ b/Sources/SwiftLlama/Models/Chat.swift
@@ -51,4 +51,15 @@ extension Chat {
         """
     }
 
+    var gemmaPrompt: String {
+        """
+        <start_of_turn>user
+        \(user)
+        <end_of_turn>
+        <start_of_turn>model
+        \(bot)
+        <end_of_turn>
+        """
+    }
+
 }

--- a/Sources/SwiftLlama/Models/Prompt.swift
+++ b/Sources/SwiftLlama/Models/Prompt.swift
@@ -8,6 +8,7 @@ public struct Prompt {
         case llama3
         case mistral
         case phi
+        case gemma
     }
 
     public let type: `Type`
@@ -33,6 +34,7 @@ public struct Prompt {
         case .chatML: encodeChatMLPrompt()
         case .mistral: encodeMistralPrompt()
         case .phi: encodePhiPrompt()
+        case .gemma: encodeGemmaPrompt()
         }
     }
 
@@ -95,6 +97,19 @@ public struct Prompt {
         \(userMessage)
         <|end|>
         <|assistant|>
+        """
+    }
+
+    private func encodeGemmaPrompt() -> String {
+        """
+        <start_of_turn>system
+        \(systemPrompt)
+        <end_of_turn>
+        \(history.suffix(Configuration.historySize).map { $0.gemmaPrompt }.joined())
+        <start_of_turn>user
+        \(userMessage)
+        <end_of_turn>
+        <start_of_turn>model
         """
     }
 }


### PR DESCRIPTION
### What 💡
- Since we can use the [Gemma](https://huggingface.co/google/gemma-7b) model from Hugging Face with llama.cpp, I want to add support for Gemma-specific prompt formatting based on the official [Gemma docs](https://ai.google.dev/gemma/docs/core/prompt-structure).

### Changes 🔨
- Modify `Prompt.swift`:
  - Add a new gemma case to support Gemma-style prompt encoding.
  - Ensure the generated prompt follows the correct <start_of_turn> and <end_of_turn> structure.
- Modify `Chat.swift`:
  - Implement proper chat history formatting for the gemma prompt style.
  - Maintain conversation context by structuring messages correctly.