### PR TITLE
Llama 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ DerivedData/
 .netrc
 TestProjects/Shared/Models/llama-2-7b.Q4_K_M.gguf
 IDEWorkspaceChecks.plist
+TestProjects/Shared/Models/*.gguf

--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,13 @@ let package = Package(
         .library(name: "SwiftLlama", targets: ["SwiftLlama"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ggerganov/llama.cpp.git", branch: "master")
+        .package(url: "https://github.com/ggerganov/llama.cpp.git", revision: "b6d6c5289f1c9c677657c380591201ddb210b649")
     ],
     targets: [
         .target(name: "SwiftLlama", 
                 dependencies: [
-                    "LlamaFramework"
+                    "LlamaFramework",
+                    .product(name: "llama", package: "llama.cpp")
                 ]),
         .testTarget(name: "SwiftLlamaTests", dependencies: ["SwiftLlama"]),
         .binaryTarget(

--- a/Sources/SwiftLlama/LlamaModel.swift
+++ b/Sources/SwiftLlama/LlamaModel.swift
@@ -8,7 +8,6 @@ class LlamaModel {
     private let sampler: UnsafeMutablePointer<llama_sampler>
     private var batch: Batch
     private var tokens: [Token]
-    private var temporaryInvalidCChars: [CChar] = []
     private var generatedTokenAccount: Int32 = 0
     private var ended = false
     private let n_len: Int32 = 1024
@@ -21,24 +20,30 @@ class LlamaModel {
         self.configuration = configuration
         llama_backend_init()
         llama_numa_init(GGML_NUMA_STRATEGY_DISABLED)
+
         var model_params = llama_model_default_params()
         #if targetEnvironment(simulator)
         model_params.n_gpu_layers = 0
         #endif
+
         guard let model = llama_load_model_from_file(path, model_params) else {
             throw SwiftLlamaError.others("Cannot load model at path \(path)")
         }
         self.model = model
+
         guard let context = llama_new_context_with_model(model, configuration.contextParameters) else {
             throw SwiftLlamaError.others("Cannot load model context")
         }
         self.context = context
+
         self.tokens = []
         self.batch = llama_batch_init(Int32(configuration.batchSize * Configuration.historySize * 2), 0, 1)
+
         self.sampler = llama_sampler_chain_init(llama_sampler_chain_default_params())
         llama_sampler_chain_add(sampler, llama_sampler_init_temp(configuration.temperature))
         llama_sampler_chain_add(sampler, llama_sampler_init_softmax())
         llama_sampler_chain_add(sampler, llama_sampler_init_dist(1234))
+
         try checkContextLength(context: context, model: model)
     }
 
@@ -53,9 +58,8 @@ class LlamaModel {
     func start(for prompt: Prompt) throws {
         ended = false
         tokens = tokenize(text: prompt.prompt, addBos: true)
-        temporaryInvalidCChars = []
-        batch.clear()
 
+        batch.clear()
         tokens.enumerated().forEach { index, token in
             batch.add(token: token, position: Int32(index), seqIDs: [0], logit: false)
         }
@@ -68,30 +72,14 @@ class LlamaModel {
     }
 
     func `continue`() throws -> String {
-        let newToken =  llama_sampler_sample(sampler, context, batch.n_tokens - 1)
+        let newToken = llama_sampler_sample(sampler, context, batch.n_tokens - 1)
 
         if llama_token_is_eog(model, newToken) || generatedTokenAccount == n_len {
-            temporaryInvalidCChars.removeAll()
             ended = true
             return ""
         }
 
-
-        let newTokenCChars = tokenToCChars(token: newToken)
-        temporaryInvalidCChars.append(contentsOf: newTokenCChars)
-
-        let newTokenStr: String
-        if let validString = String(validating: temporaryInvalidCChars + [0], as: UTF8.self) {
-            newTokenStr = validString
-            temporaryInvalidCChars.removeAll()
-        } else if let suffixIndex = temporaryInvalidCChars.firstIndex(where: { $0 != 0 }),
-                  let validSuffix = String(validating: Array(temporaryInvalidCChars.suffix(from: suffixIndex)) + [0],
-                                           as: UTF8.self) {
-            newTokenStr = validSuffix
-            temporaryInvalidCChars.removeAll()
-        } else {
-            newTokenStr = ""
-        }
+        let piece = tokenToString(token: newToken)
 
         batch.clear()
         batch.add(token: newToken, position: generatedTokenAccount, seqIDs: [0], logit: true)
@@ -100,28 +88,45 @@ class LlamaModel {
         if llama_decode(context, batch) != 0 {
             throw SwiftLlamaError.decodeError
         }
-        return newTokenStr
+        return piece
     }
 
-    private func tokenToCChars(token: llama_token) -> [CChar] {
-        var length: Int32 = 8
-        var piece = Array<CChar>(repeating: 0, count: Int(length))
+    // MARK: - Helpers
 
-        let nTokens = llama_token_to_piece(model, token, &piece, length, 0, false)
-        if nTokens >= 0 {
-            return Array(piece.prefix(Int(nTokens)))
-        } else {
-            length = -nTokens
-            piece = Array<CChar>(repeating: 0, count: Int(length))
-            let nNewTokens = llama_token_to_piece(model, token, &piece, length, 0, false)
-            return Array(piece.prefix(Int(nNewTokens)))
+    /// Convert a sampled token to a Swift String (valid UTF-8, no interleaved \0 bytes).
+    private func tokenToString(token: llama_token) -> String {
+        var cap: Int32 = 32
+        var buf = [CChar](repeating: 0, count: Int(cap))
+
+        // First attempt
+        var written = buf.withUnsafeMutableBufferPointer { p -> Int32 in
+            guard let base = p.baseAddress else { return 0 }
+            // Use the signature your llama module exposes (this matches your previous use: 6 args)
+            return llama_token_to_piece(model, token, base, cap, 0, false)
         }
+
+        // If negative, allocate required size and retry
+        if written < 0 {
+            cap = -written
+            buf = [CChar](repeating: 0, count: Int(cap))
+            written = buf.withUnsafeMutableBufferPointer { p -> Int32 in
+                guard let base = p.baseAddress else { return 0 }
+                return llama_token_to_piece(model, token, base, cap, 0, false)
+            }
+        }
+
+        let count = Int(max(0, written))
+        if count == 0 { return "" }
+
+        // Decode exact byte count (no trailing NUL included)
+        let bytes: [UInt8] = buf.prefix(count).map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
     }
 
     private func tokenize(text: String, addBos: Bool) -> [Token] {
         let utf8Count = text.utf8.count
         let n_tokens = utf8Count + (addBos ? 1 : 0) + 1
-        
+
         return Array(unsafeUninitializedCapacity: n_tokens) { buffer, initializedCount in
             initializedCount = Int(
                 llama_tokenize(model, text, Int32(utf8Count), buffer.baseAddress, Int32(n_tokens), addBos, false)
@@ -131,7 +136,6 @@ class LlamaModel {
 
     func clear() {
         tokens.removeAll()
-        temporaryInvalidCChars.removeAll()
         llama_kv_cache_clear(context)
     }
 

--- a/Sources/SwiftLlama/Models/Chat.swift
+++ b/Sources/SwiftLlama/Models/Chat.swift
@@ -29,9 +29,11 @@ extension Chat {
 
     var llama3Prompt: String {
         [
-            user.isEmpty ? nil : "<|start_header_id|>user<|end_header_id|>\(user)<|eot_id|>",
-            bot.isEmpty ? nil : "<|start_header_id|>assistant<|end_header_id|>\(bot)<|eot_id|>",
-        ].compactMap{ $0 }.joined(separator: "\n")
+            user.isEmpty ? nil : "<|start_header_id|>user<|end_header_id|>\n\(user)<|eot_id|>",
+            bot.isEmpty  ? nil : "<|start_header_id|>assistant<|end_header_id|>\n\(bot)<|eot_id|>"
+        ]
+        .compactMap { $0 }
+        .joined(separator: "\n")
     }
 
     var mistralPrompt: String {

--- a/Sources/SwiftLlama/Models/Prompt.swift
+++ b/Sources/SwiftLlama/Models/Prompt.swift
@@ -52,16 +52,36 @@ public struct Prompt {
     }
 
     private func encodeLlama3Prompt() -> String {
-        let prompt = """
-        <|start_header_id|>system<|end_header_id|>\(systemPrompt)<|eot_id|>
-        
-        \(history.suffix(Configuration.historySize).map { $0.llama3Prompt }.joined())
-        
-        <|start_header_id|>user<|end_header_id|>\(userMessage)<|eot_id|>
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone.current
+        df.dateFormat = "d MMM yyyy"
+        let today = df.string(from: Date())
+
+        let systemBlock = """
+        <|start_header_id|>system<|end_header_id|>
+
+        Cutting Knowledge Date: December 2023
+        Today Date: \(today)
+
+        \(systemPrompt)<|eot_id|>
+        """
+
+        let historyBlock = history.suffix(Configuration.historySize)
+            .map { $0.llama3Prompt }
+            .joined(separator: "\n")
+
+        let tail = """
+        <|start_header_id|>user<|end_header_id|>
+        \(userMessage)<|eot_id|>
         <|start_header_id|>assistant<|end_header_id|>
         """
-      return prompt
+
+        return [systemBlock, historyBlock, tail]
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .joined(separator: "\n\n")
     }
+
 
     private func encodeAlpacaPrompt() -> String {
         """

--- a/TestProjects/Shared/ViewModel.swift
+++ b/TestProjects/Shared/ViewModel.swift
@@ -10,14 +10,38 @@ class ViewModel {
     var usingStream = true
     private var cancallable: Set<AnyCancellable> = []
     
-    init() {
-        let path = Bundle.main.path(forResource: "llama-2-7b.Q4_K_M", ofType: "gguf") ?? ""
-        swiftLlama = (try? SwiftLlama(modelPath: path))!
+    struct LLamaModel {
+        let modelName: String
+        let type: Prompt.`Type`
+        let stopTokens: [String]
     }
-
+    
+    static let llama2model: LLamaModel = .init(
+        modelName: "llama-2-7b.Q4_K_M",
+        type: .llama,
+        stopTokens: StopToken.llama
+    )
+    
+    static let llama3model: LLamaModel = .init(
+        modelName: "Llama-3.2-3B-Instruct-Q4_K_L",
+        type: .llama3,
+        stopTokens: StopToken.llama3
+    )
+    
+    let currentModel = llama3model
+    
+    init() {
+        let path = Bundle.main.path(forResource: currentModel.modelName, ofType: "gguf") ?? ""
+        swiftLlama = (try? SwiftLlama(
+            modelPath: path,
+            modelConfiguration: .init(stopTokens: currentModel.stopTokens))
+        )!
+    }
+    
     func run(for userMessage: String) {
         result = ""
-        let prompt = Prompt(type: .llama,
+        
+        let prompt = Prompt(type: currentModel.type,
                             systemPrompt: "You are a helpful coding AI assistant.",
                             userMessage: userMessage)
         Task {
@@ -29,7 +53,7 @@ class ViewModel {
             case false:
                 await swiftLlama.start(for: prompt)
                     .sink { _ in
-
+                        
                     } receiveValue: {[weak self] value in
                         self?.result += value
                     }.store(in: &cancallable)

--- a/TestProjects/TestApp.xcodeproj/project.pbxproj
+++ b/TestProjects/TestApp.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		4BB1E3E62BE646CF00F1D21A /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1334F52BE5C4AC0020AB8E /* ViewModel.swift */; };
 		4BEE1DB62BE70024001CE949 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEE1DB52BE70024001CE949 /* main.swift */; };
 		4BEE1DBB2BE7003E001CE949 /* SwiftLlama in Frameworks */ = {isa = PBXBuildFile; productRef = 4BEE1DBA2BE7003E001CE949 /* SwiftLlama */; };
+		863E28422E54EC6900DF0B0D /* Llama-3.2-1B-Instruct.Q3_K_S.gguf in Resources */ = {isa = PBXBuildFile; fileRef = 863E28412E54EC6900DF0B0D /* Llama-3.2-1B-Instruct.Q3_K_S.gguf */; };
+		863E28432E54EC6900DF0B0D /* Llama-3.2-1B-Instruct.Q3_K_S.gguf in Resources */ = {isa = PBXBuildFile; fileRef = 863E28412E54EC6900DF0B0D /* Llama-3.2-1B-Instruct.Q3_K_S.gguf */; };
+		866F6EF22E5527B300698A28 /* Llama-3.2-3B-Instruct-Q4_K_L.gguf in Resources */ = {isa = PBXBuildFile; fileRef = 866F6EF12E5527B300698A28 /* Llama-3.2-3B-Instruct-Q4_K_L.gguf */; };
+		866F6EF32E5527B300698A28 /* Llama-3.2-3B-Instruct-Q4_K_L.gguf in Resources */ = {isa = PBXBuildFile; fileRef = 866F6EF12E5527B300698A28 /* Llama-3.2-3B-Instruct-Q4_K_L.gguf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -53,6 +57,8 @@
 		4B51A47B2BE7449700F65BFC /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		4BEE1DB32BE70024001CE949 /* swiftllama */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = swiftllama; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BEE1DB52BE70024001CE949 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		863E28412E54EC6900DF0B0D /* Llama-3.2-1B-Instruct.Q3_K_S.gguf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Llama-3.2-1B-Instruct.Q3_K_S.gguf"; sourceTree = "<group>"; };
+		866F6EF12E5527B300698A28 /* Llama-3.2-3B-Instruct-Q4_K_L.gguf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Llama-3.2-3B-Instruct-Q4_K_L.gguf"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +133,8 @@
 		4B10A3302BE5CD6600BEA6A1 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				866F6EF12E5527B300698A28 /* Llama-3.2-3B-Instruct-Q4_K_L.gguf */,
+				863E28412E54EC6900DF0B0D /* Llama-3.2-1B-Instruct.Q3_K_S.gguf */,
 				4B10A3312BE5CD6600BEA6A1 /* llama-2-7b.Q4_K_M.gguf */,
 			);
 			name = Models;
@@ -282,7 +290,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				4B1334FC2BE5C4AC0020AB8E /* Preview Assets.xcassets in Resources */,
+				866F6EF32E5527B300698A28 /* Llama-3.2-3B-Instruct-Q4_K_L.gguf in Resources */,
 				4B1334FA2BE5C4AC0020AB8E /* Assets.xcassets in Resources */,
+				863E28432E54EC6900DF0B0D /* Llama-3.2-1B-Instruct.Q3_K_S.gguf in Resources */,
 				4B58A1432BE607B900A6CF3C /* llama-2-7b.Q4_K_M.gguf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -292,7 +302,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				4B0B05812BE5C452002BC7AF /* Preview Assets.xcassets in Resources */,
+				866F6EF22E5527B300698A28 /* Llama-3.2-3B-Instruct-Q4_K_L.gguf in Resources */,
 				4B0B057E2BE5C452002BC7AF /* Assets.xcassets in Resources */,
+				863E28422E54EC6900DF0B0D /* Llama-3.2-1B-Instruct.Q3_K_S.gguf in Resources */,
 				4B10A3322BE5CD6600BEA6A1 /* llama-2-7b.Q4_K_M.gguf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -518,7 +530,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TestApp-Macos/Preview Content\"";
-				DEVELOPMENT_TEAM = 59Q22VRDBY;
+				DEVELOPMENT_TEAM = 96737BLUB5;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -527,7 +539,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "test.tim.TestApp-Macos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -547,7 +559,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TestApp-Macos/Preview Content\"";
-				DEVELOPMENT_TEAM = 59Q22VRDBY;
+				DEVELOPMENT_TEAM = 96737BLUB5;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -556,7 +568,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.2;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "test.tim.TestApp-Macos";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TestProjects/TestApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TestProjects/TestApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "b2becbcc0254795d9a140b56614e328e9054fc0127630faeab494795dc5b48bf",
+  "originHash" : "eef1cfe3b9bb7d33eb1a66d289c8b0c6dd5cf9d0ecb02a73d23eda46baa6f9ea",
   "pins" : [
     {
       "identity" : "llama.cpp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ggerganov/llama.cpp.git",
       "state" : {
-        "branch" : "master",
-        "revision" : "96b69121033d2b6b951d1b6b1b43f8b4f97dac99"
+        "revision" : "b6d6c5289f1c9c677657c380591201ddb210b649"
       }
     }
   ],


### PR DESCRIPTION
Hi,
I noticed that the current code does not correctly support Llama 3 models.
Specifically, it fails to recognize when to stop. After investigating, I found that the generated output contains many \0 characters, which prevents proper detection of stop tokens.
This fix ensures compatibility with both Llama 2 and Llama 3 models.
Additionally, I added a small LLamaModel structure in the test project, allowing users to easily switch between Llama 2 and Llama 3 models.

I can add unit tests for both models if needed. 

Best Regards,
Gabor

<img width="1223" height="734" alt="Screenshot 2025-08-19 at 19 36 38" src="https://github.com/user-attachments/assets/471d066e-6f78-4107-9b5f-6db6d73f09c8" />
<img width="1254" height="627" alt="Screenshot 2025-08-19 at 20 08 00" src="https://github.com/user-attachments/assets/279d4fad-8ca0-49c4-9022-b3089be5b588" />
